### PR TITLE
Greatly improved default output and logging for better usability

### DIFF
--- a/tidydocmd.py
+++ b/tidydocmd.py
@@ -129,48 +129,40 @@ class Section:
                 # Print the order of the h4 subsections pre- and post-sorting
                 # SOON: implement a less sprawling way of producing this output
                 log.debug(
-                    "Before sorting h4s in h3 section '%s', Parent: '%s', Grandparent: '%s': %s",
+                    "Before sorting H4 subsections in H3 section '%s', Parent: '%s', Grandparent: '%s': %s",
                     self.name,
                     parent_section_name,
                     gp_name,
                     section_names_before,
                 )
                 log.debug(
-                    "After sorting h4s in h3 section '%s', Parent: '%s', Grandparent: '%s': %s",
+                    "After sorting H4 subsections in H3 section '%s', Parent: '%s', Grandparent: '%s': %s",
                     self.name,
                     parent_section_name,
                     gp_name,
                     section_names_after,
                 )
                 if section_names_before != section_names_after:
-                    log.info(
-                        "Before sorting h4s in h3 section '%s', Parent: '%s', Grandparent: '%s': %s",
-                        self.name,
-                        parent_section_name,
-                        gp_name,
-                        section_names_before,
-                    )
-                    log.info(
-                        "After sorting h4s in h3 section '%s', Parent: '%s', Grandparent: '%s': %s",
-                        self.name,
-                        parent_section_name,
-                        gp_name,
-                        section_names_after,
-                    )
-                    calculate_reshuffle_percentage(
+                    # If the order of subsections has changed, calculate
+                    # the percentage of reshuffled names and print the
+                    # details of each reshuffled name.
+                    output_lines = calculate_reshuffle_percentage(
                         self.name,
                         parent_section_name,
                         section_names_before,
                         section_names_after,
                     )
+                    for line in output_lines:
+                        log.info(line)  # Print the reshuffle details
                 else:
                     log.info(
-                        "No change in order of h4s in h3 section '%s', Parent: '%s'",
-                        self.name,
+                        "'%s':'%s': no changes made to the order of %s names",
                         parent_section_name,
+                        self.name,
+                        str(len(section_names_before))
                     )
             else:
-                log.debug("No h4 subsections in h3 section '%s'", self.name)
+                log.debug("No H4 subsections in H3 section '%s'", self.name)
         else:
             log.debug(
                 "Not processing as a chosen H3: '%s' at depth %s with parent '%s'",
@@ -231,21 +223,25 @@ def calculate_reshuffle_percentage(
     reshuffled = len(moved)
     reshuffle_percentage = round(reshuffled / len(section_name_before) * 100)
 
+    output_lines = []
     shuffle_mess = (
-        f"{this_parent}:{this_section}: alphabetized {reshuffled} out of "
+        f"{this_parent}:{this_section}: alphabetized {reshuffled} of "
         f"{len(section_name_before)} names ({reshuffle_percentage}%):"
     )
-    print(shuffle_mess)
+    output_lines.append(shuffle_mess)
+    
     for name in moved:
         old_index = section_name_before.index(name)
         new_index = section_name_after.index(name)
         if old_index == 0:
-            moved_info = f"* {name} (was first, now is after {section_name_after[new_index - 1]})"
+            moved_info = f"* {name} (was first, now after {section_name_after[new_index - 1]})"
         elif new_index == 0:
-            moved_info = f"* {name} (was after {section_name_before[old_index - 1]}, now is first)"
+            moved_info = f"* {name} (was after {section_name_before[old_index - 1]}, now first)"
         else:
-            moved_info = f"* {name} (was after {section_name_before[old_index - 1]}, now is after {section_name_after[new_index - 1]})"
-        print(moved_info)
+            moved_info = f"* {name} (was after {section_name_before[old_index - 1]}, now after {section_name_after[new_index - 1]})"
+        output_lines.append(moved_info)
+
+    return output_lines
 
 
 def parse_file(input_path, debug=False):


### PR DESCRIPTION
Various changes to make the script's logging and output more user-friendly, informative, and maintainable!

Logging clarity: modified the log messages for better readability and consistency. 

Reduced redundancy: simplified the logging process by removing repetitive log.info statements. This change streamlines the code and focuses on essential info.

Improved reshuffle reporting: modified the calculate_reshuffle_percentage function. The function now returns a list of formatted strings detailing the reshuffle process instead of directly printing them. This allows for more controlled and structured logging.

Enhanced reshuffle output: added logic to loop through the output of calculate_reshuffle_percentage and log each line, enhancing the visibility of reshuffle details in the log.

Simplified no-change logging: streamlined the logging message for sections where no changes occurred, making it more succinct and informative.

* Sparkly new output: 
TidyDocMD % python ./tidydocmd.py -i ~/dummy-testdata.md -o /tmp/sorted-data.md
2023-12-09 03:23:22,453 Speakers:United States: alphabetized 4 of 11 names (36%):
2023-12-09 03:23:22,453 * Crystal Q. Anderson (was after Julia Zoutoforder, now first)
2023-12-09 03:23:22,453 * Jana Zeitgeist (was after Zuriel O'Brien, now after Sitara Singh)
2023-12-09 03:23:22,453 * Zuriel O'Brien (was after Sarah 'First Post' KQ, now after Raelyn McCullen)
2023-12-09 03:23:22,453 * Sarah 'First Post' KQ (was first, now after Toshiya Imai)
2023-12-09 03:23:22,454 Speakers:Canada: alphabetized 6 of 7 names (86%):
2023-12-09 03:23:22,454 * Xena Xia (was after Anabella Bainbridge, now after Maya Klancikova)
2023-12-09 03:23:22,454 * Maya Klancikova (was after Buzzbunni, now after Mya Johnson)
2023-12-09 03:23:22,454 * Zoey Alice Zackarys (was after Mya Johnson, now after Xena Xia)
2023-12-09 03:23:22,454 * Mya Johnson (was after Maya Klancikova, now after Buzzbunni)
2023-12-09 03:23:22,454 * Buzzbunni (was after Zena Zelastone, now after Anabella Bainbridge)
2023-12-09 03:23:22,454 * Anabella Bainbridge (was after Zoey Alice Zackarys, now first)
2023-12-09 03:23:22,455 'Speakers':'Colombia': no changes made to the order of 1 names
2023-12-09 03:23:22,455 'Speakers':'Europe': no changes made to the order of 2 names
2023-12-09 03:23:22,455 'Speakers':'Lebanon': no changes made to the order of 2 names
2023-12-09 03:23:22,456 Organizers:United States: alphabetized 2 of 4 names (50%):
2023-12-09 03:23:22,456 * Jocelyn Danielle Eldon-Che (was after Juniper Archer, now after Juniper Archer)
2023-12-09 03:23:22,456 * Juniper Archer (was after Lara Zubiri, now first)
2023-12-09 03:23:22,456 'Organizers':'Canada': no changes made to the order of 3 names
2023-12-09 03:23:22,456 'Organizers':'Brazil': no changes made to the order of 3 names
2023-12-09 03:23:22,456 Organizers:Japan: alphabetized 1 of 2 names (50%):
2023-12-09 03:23:22,457 * Maithili Dubey (was after Yuna Mitty, now first)
2023-12-09 03:23:22,457 Mentors:United States: alphabetized 1 of 5 names (20%):
2023-12-09 03:23:22,457 * Shane Lawrence (was after Zara Zamaan, now after Alana Zappa Kaufman)
2023-12-09 03:23:22,457 'Mentors':'Canada': no changes made to the order of 1 names
2023-12-09 03:23:22,457 'Mentors':'India': no changes made to the order of 3 names
2023-12-09 03:23:22,457 Mentors:Nigeria: alphabetized 1 of 2 names (50%):
2023-12-09 03:23:22,457 * Amina Mohammed (was after Zainab Zaman, now first)
